### PR TITLE
Addressing #33. Proper handling of coefficients. 

### DIFF
--- a/circuit.py
+++ b/circuit.py
@@ -104,46 +104,43 @@ class Circuit(object):
                 if isinstance(self.ops[index + 1], Measurement):
                     break
                 
-                self.commute_pi_over_four_rotation(index)
+                self.commute_rotation(index)
                 index += 1
 
 
-    def commute_pi_over_four_rotation(self, index: int) -> None:
+    def commute_rotation(self, index: int) -> None:
         """
-        Commute a pi/4 rotation block pass its' next block.
+        Commute a rotation block pass its neighbor block.
+
+        Args:
+            index (int): Index of the targeted block in the current circuit. 
+
         """
         next_block = index + 1
 
         if next_block >= len(self.ops):
             raise Exception("No operation to commute past")
 
-        if not isinstance(self.ops[index], Rotation) or not isinstance(self.ops[index+1], Rotation):
-            raise Exception("Can only commute rotations")
-
-        if not cast(Rotation,self.ops[index]).rotation_amount in {Fraction(1,4),Fraction(-1,4)}:
-            raise Exception("First operand must be +-pi/4 Pauli rotation")
-
+        # Need to calculate iPP' when PP' = -P'P (anti-commute)
         if not self.are_commuting(index, next_block):
-
-            if cast(Rotation,self.ops[index]).rotation_amount != Fraction(1,4):
-                raise NotImplemented("Can only commute pi/4 rotations when rotation exponents anticommute")
-
-            # for tracking # of i (see issue #28)
-            # i is required for an anti-commute operators pair
-            i_count = 0     
+            product_of_coefficients = 1
             
             for i in range(self.qubit_num):
-                new_op = PauliOperator.are_commuting(self.ops[index].get_op(i), self.ops[next_block].get_op(i))
+                new_op = PauliOperator.multiply_operators(self.ops[index].get_op(i), self.ops[next_block].get_op(i))
                 
                 self.ops[next_block].change_single_op(i, new_op[1])
-                if not new_op[0]: i_count += 1
+                product_of_coefficients *= new_op[0]
 
+            # Flip the phase if product of coefficients is negative
+            # Product of coefficients will always be either i or -i (see issues #28 for proof)
+            product_of_coefficients /= 1j
+            if isinstance(self.ops[next_block], Measurement):
+                if product_of_coefficients.real < 0:
+                    self.ops[next_block].isNegative = not self.ops[next_block].isNegative
 
-            # Adjust the rotation based on i_count (see issue 28).
-            # It flips the phase when there is an odd number of i pairs, excluding the first i.
-            if ((i_count - 1) / 2) % 2 != 0: 
-                self.ops[next_block].rotation_amount *= -1
-    
+            else:
+                self.ops[next_block].rotation_amount *= -1 if product_of_coefficients.real < 0 else 1 
+
         temp = self.ops[index]
         self.ops[index] = self.ops[next_block]
         self.ops[next_block] = temp
@@ -173,7 +170,7 @@ class Circuit(object):
         # The loop below computes (c_1*...*c_n) in ret_val
         
         for i in range(self.qubit_num):
-            ret_val *= 1 if PauliOperator.are_commuting(self.ops[block1].get_op(i), self.ops[block2].get_op(i))[0] else -1
+            ret_val *= 1 if PauliOperator.are_commuting(self.ops[block1].get_op(i), self.ops[block2].get_op(i)) else -1
 
         return (ret_val > 0) 
     

--- a/circuit.py
+++ b/circuit.py
@@ -50,7 +50,9 @@ class Circuit(object):
             rotation (Rotation): Targeted rotation
             index (int, optional): Index location. Default: End of the circuit
         """
-        assert new_block.qubit_num == self.qubit_num
+
+        if new_block.qubit_num != self.qubit_num:
+            raise Exception("Amount of qubits do not match.")
 
         if index is None:
             index = len(self)
@@ -58,9 +60,6 @@ class Circuit(object):
         # print(rotation)
         self.ops.insert(index, new_block)
 
-
-    def get_operations(self) -> List[PauliProductOperation]:
-        return self.ops
 
     def add_single_operator(self, qubit: int, operator_type: PauliOperator, rotation_amount: Fraction, index: int = None) -> None:
         """
@@ -115,10 +114,10 @@ class Circuit(object):
         """
         next_block = index + 1
 
-        if index+1 >= len(self.ops):
+        if next_block >= len(self.ops):
             raise Exception("No operation to commute past")
 
-        if not isinstance(self.ops[index], Rotation) or not isinstance(self.ops[index+1],Rotation):
+        if not isinstance(self.ops[index], Rotation) or not isinstance(self.ops[index+1], Rotation):
             raise Exception("Can only commute rotations")
 
         if not cast(Rotation,self.ops[index]).rotation_amount in {Fraction(1,4),Fraction(-1,4)}:
@@ -179,10 +178,12 @@ class Circuit(object):
         return (ret_val > 0) 
     
 
-    def merge_measurement(self, index: int) -> None:
+    def absorb_pi_over_four_rotation(self, index: int) -> None:
         """
-        Merge a rotation block with it's neighbor measurement block. 
+        Merge a pi/4 rotation block with it's neighbor measurement block. 
         """
+
+        # TODO: Implement this 
         pass
 
 

--- a/logical_lattice_ops.py
+++ b/logical_lattice_ops.py
@@ -80,7 +80,7 @@ class LogicalLatticeComputation:
             raise Exception("Unsupported PauliProductOperation " + repr(op))
 
         operations_queue: Deque[Union[Rotation, LogicalLatticeOperation]] \
-            = deque(map(to_lattice_operation, self.circuit.get_operations()))
+            = deque(map(to_lattice_operation, self.circuit.ops))
 
         while len(operations_queue) > 0:
             current_op = operations_queue.popleft()

--- a/rotation.py
+++ b/rotation.py
@@ -80,6 +80,10 @@ class PauliProductOperation(object):
             qubit (int): Targeted qubit
             new_op (PauliOperator): New operator type (I, X, Z, Y)
         """
+
+        if not isinstance(new_op, PauliOperator):
+            raise TypeError("Cannot add type", type(new_op), "to circuit")
+
         self.ops_list[qubit] = new_op
 
     


### PR DESCRIPTION
Changes to the implementation of Pauli rotation commutation (to address #33) as follow:
- Added `PauliOperator.multiply_operators()` which will return the nearest result of PP' and the coefficients required (either `1` for commuting cases or `±i` for anti-commute cases) and  for such result. `Circuit.commute_rotation()` will adjust the phase based on the product of these coefficients. 
- Updated `Circuit.commute_rotation()` to handle commutation of an Pauli rotation block past a measurement block. Phase of rotations do not matter. Some checks in #31 has been removed based on this.
- `PauliOperator.are_commuting()` now only returns whether the 2 specified operators are commuting or not (bool). 
- Functions names and descriptions modified to reflect this change.